### PR TITLE
modify process pattern matching to finding any substring in the entir…

### DIFF
--- a/little_brother/client_process_handler.py
+++ b/little_brother/client_process_handler.py
@@ -161,9 +161,9 @@ class ClientProcessHandler(process_handler.ProcessHandler):
                 username = p_login_mapping.get_login_by_uid(p_server_group=p_server_group, p_uid=uid)
 
                 if username is not None and username in p_process_regex_map:
-                    proc_name = proc.name()
+                    proc_cmdline = ' '.join(proc.cmdline())
 
-                    if p_process_regex_map[username].match(proc_name):
+                    if p_process_regex_map[username].search(proc_cmdline):
                         start_time = datetime.datetime.fromtimestamp(proc.create_time(),
                                                                      datetime.timezone.utc).astimezone().replace(
                             tzinfo=None)


### PR DESCRIPTION
this pull request gives a bit more power to the process matching by:
1) match against the entire command line instead of just the process name
2) use search instead of match to allow matching a substring at any position, and not just at the start of the commandline

this changes the behavior of littlebrother a little bit: existing rules should still result in a positive match after this change, if they did so before. BUT: existing rules can now also result in a positive match if they did not before (e.g. due to the pattern occurring in the full commandline, but not in the process name, or due to the pattern occurring in a substring and not at position 0 in the string).

this is useful for me, to e.g. match against e.g. java games being played. (Like Minecraft). In those cases the process name is java, but I do not want to track all java usage, only minecraft. Providing "minecraft" as a pattern with this pull request allows me to do just that!

if you do not consider this an improvement, then I fully understand, feel free to ignore this pull request then. A more elaborate solution where you can choose between matching the process name v.s. matching the commandline might be a solution then.

